### PR TITLE
Peakable

### DIFF
--- a/source/river/core/package.d
+++ b/source/river/core/package.d
@@ -8,6 +8,11 @@ module river.core;
  */
 public import river.core.stream : Stream;
 
+/** 
+ * Peak-supporting trait
+ */
+public import river.core.peakable : Peakable;
+
 /**
  * Error handling
  */

--- a/source/river/core/package.d
+++ b/source/river/core/package.d
@@ -9,9 +9,9 @@ module river.core;
 public import river.core.stream : Stream;
 
 /** 
- * Peak-supporting trait
+ * Peek-supporting trait
  */
-public import river.core.peakable : Peakable;
+public import river.core.peekable : Peekable;
 
 /**
  * Error handling

--- a/source/river/core/peakable.d
+++ b/source/river/core/peakable.d
@@ -1,3 +1,6 @@
+/** 
+ * Peak-supporting trait
+ */
 module river.core.peakable;
 
 /** 

--- a/source/river/core/peakable.d
+++ b/source/river/core/peakable.d
@@ -8,5 +8,18 @@ module river.core.peakable;
  */
 public interface Peakable
 {
-    
+    /** 
+     * Reads bytes from the stream into the provided array
+     * and returns without any further waiting, at most the
+     * number of bytes read will be the length of the provided
+     * array, at minimum a single byte.
+     *
+     * The underlying buffer of the `Stream` will not have
+     * said bytes removed from it however.
+     *
+     * Params:
+     *   toArray = the buffer to read into
+     * Returns: the number of bytes read 
+     */
+    public ulong peak(byte[] toArray);
 }

--- a/source/river/core/peakable.d
+++ b/source/river/core/peakable.d
@@ -25,4 +25,7 @@ public interface Peakable
      * Returns: the number of bytes read 
      */
     public ulong peak(byte[] toArray);
+
+    // TODO: peakFully
+    public ulong peakFully(byte[] toArray);
 }

--- a/source/river/core/peakable.d
+++ b/source/river/core/peakable.d
@@ -1,0 +1,12 @@
+module river.core.peakable;
+
+/** 
+ * A stream which implements `Peakable` means that one
+ * can do a read in a manner which copies the length of
+ * data requested into a buffer but without removing it
+ * from the `Stream`'s underlying buffer
+ */
+public interface Peakable
+{
+    
+}

--- a/source/river/core/peekable.d
+++ b/source/river/core/peekable.d
@@ -1,7 +1,7 @@
 /** 
- * Peak-supporting trait
+ * Peek-supporting trait
  */
-module river.core.peakable;
+module river.core.peekable;
 
 /** 
  * A stream which implements `Peakable` means that one
@@ -9,7 +9,7 @@ module river.core.peakable;
  * data requested into a buffer but without removing it
  * from the `Stream`'s underlying buffer
  */
-public interface Peakable
+public interface Peekable
 {
     /** 
      * Reads bytes from the stream into the provided array
@@ -24,8 +24,8 @@ public interface Peakable
      *   toArray = the buffer to read into
      * Returns: the number of bytes read 
      */
-    public ulong peak(byte[] toArray);
+    public ulong peek(byte[] toArray);
 
     // TODO: peakFully
-    public ulong peakFully(byte[] toArray);
+    public ulong peekFully(byte[] toArray);
 }

--- a/source/river/core/peekable.d
+++ b/source/river/core/peekable.d
@@ -26,6 +26,16 @@ public interface Peekable
      */
     public ulong peek(byte[] toArray);
 
-    // TODO: peakFully
+    /** 
+     * Reads bytes from the stream into the provided array
+     * until the array is fully-filled
+     *
+     * The underlying buffer of the `Stream` will not have
+     * said bytes removed from it however.
+     *
+     * Params:
+     *   toArray = the buffer to read into
+     * Returns: the number of bytes read
+     */
     public ulong peekFully(byte[] toArray);
 }

--- a/source/river/impls/sock.d
+++ b/source/river/impls/sock.d
@@ -381,7 +381,7 @@ unittest
 }
 
 /**
- * This tests the `Peeekable` capability of `SockStream`
+ * This tests the `Peekable` capability of `SockStream`
  */
 unittest
 {

--- a/source/river/impls/sock.d
+++ b/source/river/impls/sock.d
@@ -9,7 +9,7 @@ import std.socket;
 /** 
  * Provides a stream interface to a `Socket` which has 
  */
-public class SockStream : Stream, Peakable
+public class SockStream : Stream, Peekable
 {
     /** 
      * Underlying socket
@@ -223,7 +223,7 @@ public class SockStream : Stream, Peakable
      *   toArray = the buffer to read into
      * Returns: the number of bytes read 
      */
-    public override ulong peak(byte[] toArray)
+    public override ulong peek(byte[] toArray)
     {
         // Ensure the stream is open
         openCheck();
@@ -250,7 +250,7 @@ public class SockStream : Stream, Peakable
     }
 
     // TODO: Comment
-    public override ulong peakFully(byte[] toArray)
+    public override ulong peekFully(byte[] toArray)
     {
         // Ensure the stream is open
         openCheck();
@@ -447,7 +447,7 @@ unittest
 
     byte[] receivedData;
     receivedData.length = 4;
-    ulong cnt = (cast(Peakable)stream).peak(receivedData);
+    ulong cnt = (cast(Peekable)stream).peek(receivedData);
     writeln(cnt);
     writeln("peek (least): ", receivedData);
 
@@ -456,13 +456,13 @@ unittest
 
     /** 
      * By now we hope all the data we wanted has arrived
-     * FULLY and let's do a few `peak()`s then
+     * FULLY and let's do a few `peek()`s then
      */
     for(int i = 0; i < 2; i++)
     {
         byte[] receivedData2;
         receivedData2.length = 4;
-        cnt = (cast(Peakable)stream).peak(receivedData2);
+        cnt = (cast(Peekable)stream).peek(receivedData2);
         writeln(cnt);
         writeln("peek (least,arrivedFully): ", receivedData2);
     }

--- a/source/river/impls/sock.d
+++ b/source/river/impls/sock.d
@@ -9,7 +9,7 @@ import std.socket;
 /** 
  * Provides a stream interface to a `Socket` which has 
  */
-public class SockStream : Stream
+public class SockStream : Stream, Peakable
 {
     /** 
      * Underlying socket
@@ -209,6 +209,72 @@ public class SockStream : Stream
         /* Closes the connection */
         socket.close();
     }
+
+    /** 
+     * Reads bytes from the stream into the provided array
+     * and returns without any further waiting, at most the
+     * number of bytes read will be the length of the provided
+     * array, at minimum a single byte.
+     *
+     * The underlying buffer of the `Stream` will not have
+     * said bytes removed from it however.
+     *
+     * Params:
+     *   toArray = the buffer to read into
+     * Returns: the number of bytes read 
+     */
+    public override ulong peak(byte[] toArray)
+    {
+        // Ensure the stream is open
+        openCheck();
+
+        // Receive from the socket `toArray.length`
+        ptrdiff_t status = socket.receive(toArray, SocketFlags.PEEK);
+
+        // If the remote end closed the connection
+        if(status == 0)
+        {
+            throw new StreamException(StreamError.CLOSED);
+        }
+        // TODO: Handle like above, but some custom error message, then throw exception
+        else if(status < 0)
+        {
+            // TODO: We should examine the error
+            throw new StreamException(StreamError.OPERATION_FAILED);
+        }
+        // If the message was correctly received
+        else
+        {
+            return status;
+        }
+    }
+
+    // TODO: Comment
+    public override ulong peakFully(byte[] toArray)
+    {
+        // Ensure the stream is open
+        openCheck();
+
+        // Receive from the socket `toArray.length`
+        ptrdiff_t status = socket.receive(toArray, SocketFlags.PEEK | cast(SocketFlags)MSG_WAITALL);
+
+        // If the remote end closed the connection
+        if(status == 0)
+        {
+            throw new StreamException(StreamError.CLOSED);
+        }
+        // TODO: Handle like above, but some custom error message, then throw exception
+        else if(status < 0)
+        {
+            // TODO: We should examine the error
+            throw new StreamException(StreamError.OPERATION_FAILED);
+        }
+        // If the message was correctly received
+        else
+        {
+            return status;
+        }
+    }
 }
 
 version(unittest)
@@ -281,7 +347,6 @@ unittest
             {
                 
             }
-            
         }
     }
 
@@ -311,7 +376,103 @@ unittest
     assert(cnt >= 1 && cnt <= 3);
     assert(receivedData2 == [21, 0, 0] || receivedData2 == [21, 1, 0] || receivedData2 == [21, 1, 2]);
 
-
     // Finally close the stream
     stream.close();
+}
+
+/**
+ * This tests the `Peeekable` capability of `SockStream`
+ */
+unittest
+{
+    string testDomainStr = "/tmp/riverTestUNIXSock.sock";
+    UnixAddress testDomain = new UnixAddress(testDomainStr);
+
+    scope(exit)
+    {
+        // Remove the UNIX domain file, else we will get a problem
+        // ... creating it next time we run
+        remove(testDomainStr);
+    }
+
+    Socket server = new Socket(AddressFamily.UNIX, SocketType.STREAM);
+    server.bind(testDomain);
+    server.listen(0);
+    
+    class ServerThread : Thread
+    {
+        private Socket serverSocket;
+
+        this(Socket serverSocket)
+        {
+            super(&run);
+            this.serverSocket = serverSocket;
+        }
+
+        private void run()
+        {
+            /** 
+             * Accept the socket and create a `SockStream`
+             * from it to test out writing
+             */   
+            Socket clientSocket = serverSocket.accept();
+            Stream clientStream = new SockStream(clientSocket);
+
+           
+            try
+            {
+                ubyte[] data = [65];
+                clientStream.writeFully(cast(byte[])data);
+
+                Thread.sleep(dur!("seconds")(2));
+
+                data = [66, 66, 65];
+                clientStream.writeFully(cast(byte[])data);
+            }
+            catch(StreamException e)
+            {
+
+            }
+            
+        }
+    }
+
+    Thread serverThread = new ServerThread(server);
+    serverThread.start();
+
+    Socket clientConnection = new Socket(AddressFamily.UNIX, SocketType.STREAM);
+    clientConnection.connect(testDomain);
+
+    Stream stream = new SockStream(clientConnection);
+
+    byte[] receivedData;
+    receivedData.length = 4;
+    ulong cnt = (cast(Peakable)stream).peak(receivedData);
+    writeln(cnt);
+    writeln("peek (least): ", receivedData);
+
+    // Give the server some time to send the [66, 66, 65]
+    Thread.sleep(dur!("seconds")(3));
+
+    /** 
+     * By now we hope all the data we wanted has arrived
+     * FULLY and let's do a few `peak()`s then
+     */
+    for(int i = 0; i < 2; i++)
+    {
+        byte[] receivedData2;
+        receivedData2.length = 4;
+        cnt = (cast(Peakable)stream).peak(receivedData2);
+        writeln(cnt);
+        writeln("peek (least,arrivedFully): ", receivedData2);
+    }
+    
+    /** 
+     * Now let's dequeue it all
+     */
+    byte[] receivedData3;
+    receivedData3.length = 4;
+    cnt = stream.readFully(receivedData3);
+    writeln(cnt);
+    writeln("read (fully): ", receivedData3);
 }


### PR DESCRIPTION
- Added new interface
- A stream which implements `Peakable` means that one can do a read in a manner which copies the length of data requested into a buffer but without removing it from the `Stream`'s underlying buffer